### PR TITLE
fix: handling of tamper option

### DIFF
--- a/burp-to-sqlmap.py
+++ b/burp-to-sqlmap.py
@@ -77,7 +77,7 @@ def main():
     else:
         level_value = ""
 
-    if args.level:
+    if args.tamper:
         tamper_value = "--tamper=" + args.tamper + " "
     else:
         tamper_value = ""


### PR DESCRIPTION
Without this fix the following occurred

$ python burp-to-sqlmap.py -f burp -o result -s /usr/share/sqlmap --risk 3 --level 3
Traceback (most recent call last):
  File "burp-to-sqlmap.py", line 191, in <module>
    main()
  File "burp-to-sqlmap.py", line 81, in main
    tamper_value = "--tamper=" + args.tamper + " "
TypeError: cannot concatenate 'str' and 'NoneType' objects